### PR TITLE
Enabled changing the background colour without overwriting the drawing, and cleaning up the code

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,8 @@
     <h2>Options</h2>
 
     <button id="undo">Undo</button>
+    <button id="redo">Redo</button>
+    <button id="save">Save</button>
 
     <div class="selectorArea" id="backgroundSelectorArea">
       <label for="backgroundColour">Background colour: </label>
@@ -55,6 +57,7 @@
   </div>
 
   <canvas id="drawingArea"></canvas>
+  <canvas id="drawingBackground"></canvas>
 
   <script src="script.js"></script>
 

--- a/script.js
+++ b/script.js
@@ -1,160 +1,148 @@
-//////// Line 41 >> Sets background colour, BUT overlays what has already been drawn
-//////// Set a cmd-z option? (how??)
+//////// SETTING UP THE CANVASES AND VARIABLES ////////
 
-// Set const "canvas" to be the canvas div
+// Set the canvas to draw on to be canvas element #drawingArea, and the canvas containing the background colour to be the canvas element #drawingBackground
 const canvas = document.querySelector("#drawingArea");
-// Set context to be 2d (?), getting the data from the "canvas" variable
-let ctx = canvas.getContext("2d");
+const background = document.querySelector("#drawingBackground");
 
-let temp = "";
+// Set the 2D contexts of each canvas
+const ctx = canvas.getContext("2d");
+const backCtx = background.getContext("2d");
 
-// Set the canvas to span the entire window
-// Have to set this in order to enable drawing functions below
+// Set the basic properties (size and position) of both canvas elements
+// Want the canvases to overlap completely, so they should have the same siza and position values
 canvas.width = (window.innerWidth * 0.8);
 canvas.height = (window.innerHeight * 0.816);
-//
+background.width = (window.innerWidth * 0.8);
+background.height = (window.innerHeight * 0.816);
+
 canvas.style.top = "18.4vh";
 canvas.style.left = "20vw";
-// canvas.style.border = "2px solid purple";
+background.style.top = "18.4vh";
+background.style.left = "20vw";
 
+// Set the default brushstroke values
+// Don't need to set these for the background canvas, as will not be drawing on that canvas
+ctx.lineJoin = "round";   // Set the default style of brushstoke joints  // round / square / butt
+ctx.lineCap = "round";    // Set the default style of brushstoke ends  // round / square / butt
+ctx.globalCompositeOperation = "source-over";   // Set the default brushstroke effect
 
-// Set the default colour of the brushstrokes
-    // ctx.strokeStyle = "tomato";
-// Set the default style of brushstoke joints
-ctx.lineJoin = 'round'; // round / square / butt
-// Set the default style of brushstoke ends
-ctx.lineCap = 'round'; // round / square / butt
-// Set the width of the brush strokes
-    // ctx.lineWidth = 10;
-// Set the colour to combine with existing colour when doubling over previous brush strokes
-ctx.globalCompositeOperation = 'source-over';
-
-//// Set variables as 'let', as the values of these variables will change when moving the mouse/painting on the canvas
-let isDrawing = false;  // Set default state to be not-drawing (ie when not pressing down the mouse)
-let lastX = 0;
-let lastY = 0;
-let hue = 0;
+// Set the global variables
+let isDrawing = false;    // Set the default state to be not-drawing
+let lastX;
+let lastY;
 let direction = true;
-let newColor = "#000";
-let newBackground = "#fff";
-let newWidth = 10;
+let color;
+let backgroundColor;
+let strokeWidth = 10;    // Set default width of the brushstroke to match the default value specified for the HTML input element
 
-const colorChange = document.getElementById('colorSelector');
-const backgroundChange = document.getElementById('backgroundSelector');
-const widthChange = document.getElementById('widthSelector');
+// Define the variables for the HTML input elements (for the drawing effects)
+// For the colour and width of the brush strokes:
+const colorChange = document.getElementById("colorSelector");
+const widthChange = document.getElementById("widthSelector");
+// For the brush edge effect:
+const brushEffectList = document.getElementById("brushEffectList");
+const brushEffectOptions = document.querySelectorAll("#brushEffectList input");
+const numOfBrushEffects = brushEffectOptions.length;
+// For the brush painting effect:
+const colorEffectList = document.getElementById("effectList");
+const colorEffectOptions = document.querySelectorAll("#effectList input");
+const numOfColorEffects = colorEffectOptions.length;
+// For the background colour:
+const backgroundChange = document.getElementById("backgroundSelector");
 
-// Listening for 'change' within the constant 'colorChange'
-// When that happens >> update the newColor variable
-colorChange.addEventListener('change', (e) => {
-  newColor = e.srcElement.value;
-});
-backgroundChange.addEventListener('change', (e) => {
-  newBackground = e.srcElement.value;
-  ctx.fillStyle = newBackground;
-  ctx.fillRect(0, 0, canvas.width, canvas.height);
-})
-widthChange.addEventListener('change', (e) => {
-  newWidth = e.srcElement.value;
-});
+// Define the variable that will store the brushstroke image data
+let canvasStorage;
+// Define the variable that will store the background image data
+let backgroundStorage;
+// Define the undo button
+const undo = document.getElementById("undo");
+// Define the save button
+const save = document.getElementById("save");
 
+//////// DRAWING FUNCTIONS ////////
 
-
-//////////////////////////////////////////////////////
-//////////////////////////////////////////////////////
-
-// Enable brush effect choices
-
-const brushEffectList = document.getElementById('brushEffectList');
-const brushEffectOptions = document.querySelectorAll('#brushEffectList input');
-const nOfBrushEffects = brushEffectOptions.length;
-const brushEffectValues = document.querySelectorAll('.brushValue');
-
-brushEffectList.addEventListener('change', (e) => {
-  for (i = 0; i < nOfBrushEffects; i++) {
-    if (brushEffectOptions[i].checked === true) {
-
-      // ctx.lineJoin = brushEffectOptions[i].value; >> for some reason, this will not update the variable >> look into how to fix it && whether it is needed for the desired brush stroke effect
-      ctx.lineCap = brushEffectOptions[i].value;
-    }
-  }
-});
-
-
-
-//////////////////////////////////////////////////////
-//////////////////////////////////////////////////////
-
-// Enable colour effect choices
-
-const effectList = document.getElementById('effectList');
-
-const effectOptions = document.querySelectorAll('#effectList input');
-
-const nOfEffects = effectOptions.length;
-const effectValues = document.querySelectorAll('.effectValue');
-
-// Listen for mousedown/clicking within the list of effect options
-effectList.addEventListener('change', (e) => {
-
-  // When click within the list >> loop through all items within the list
-  for (i = 0; i < nOfEffects; i++) {
-
-    // check whether they were the option that was chosen
-    // if yes >> set 'ctx.globalCompositeOperation' to that value
-    if (effectOptions[i].checked === true) {
-
-      ctx.globalCompositeOperation = effectOptions[i].value;
-    }
-  }
-});
-
-
-
-//////////////////////////////////////////////////////
-//////////////////////////////////////////////////////
-
-// Enable drawing on the canvas
-
+// Define the draw function >> Tells the browser what to do when the user is drawing (ie have their mouse down and is moving it around)
 function draw(e) {
-  if(!isDrawing) return;  // if currently not-drawing, stop the function from running
+  if(!isDrawing) return;    // If isDrawing is set to False (ie mouse not down on the canvas) >> exit the function
 
-  // if currently drawing, execute the following:
+  // If isDrawing is set to True, execute the following code:
+  ctx.strokeStyle = color;
+  ctx.lineWidth = strokeWidth;
 
-  ctx.strokeStyle = newColor;
-  // `hsl(${hue}, 100%, 50%)`
-  ctx.lineWidth = newWidth;
-
-  // Set where the brush stroke should start from
+  // Define where the brush stroke should start from (starting location)
   ctx.beginPath();
-  // Set where the brush stroke should go to
+  // Define where the brush stroke should move to:
   ctx.moveTo(lastX, lastY);
   ctx.lineTo(e.offsetX, e.offsetY);
   ctx.stroke();
-  [lastX, lastY] = [e.offsetX, e.offsetY];    // is equivalent to:  lastX = e.offsetX;  AND lastY = e.offsetY;
-
-  // To create rainbow effect in the brush colour:
-  // hue++;
-  // if(hue >= 360) {
-  //   hue = 0;
-  // }
+  [lastX, lastY] = [e.offsetX, e.offsetY];
 }
 
-// Add event listeners to tell the [program] when drawing is happening and not
-canvas.addEventListener('mousedown', (e) => { // when mouse-down >> means it's drawing on the canvas
-  temp = ctx.getImageData(0,0,620,620);   // Save the next-to-last version of the canvas to the 'temp' variable
-      // Save each 'temp' version to the backup array
-  isDrawing = true;
+// Define function to enable changing the colour of brush strokes
+colorChange.addEventListener("change", (e) => color = e.srcElement.value);
+// Define function to enable changing the width of brush strokes
+widthChange.addEventListener("change", (e) => strokeWidth = e.srcElement.value);
+// Define function to enable changing the brush edge effect
+brushEffectList.addEventListener("change", (e) => {
+  for (i = 0; i < numOfBrushEffects; i++) {   // Loop through the list of HTML input elements
+    if (brushEffectOptions[i].checked === true) {   // Checked each option to see whether it's been checked
+      ctx.lineCap = brushEffectOptions[i].value;    // If it has been checked >> Update the lineCap value to that of the chosen effect
+    }
+  }
+});
+// Define function to enable changing the brush painting effect
+colorEffectList.addEventListener("change", (e) => {
+  for (i = 0; i < numOfColorEffects; i++) {
+    if (colorEffectOptions[i].checked === true) {
+      ctx.globalCompositeOperation = colorEffectOptions[i].value;
+    }
+  }
+});
+
+// Define the background colour of the background canvas
+backgroundChange.addEventListener("change", (e) => {
+  backgroundColor = e.srcElement.value;
+  backCtx.fillStyle = backgroundColor;
+  backCtx.fillRect(0, 0, background.width, background.height);
+});
+
+//////// Enable the drawing ////////
+
+// Start drawing when click on the canvas (mouse down)
+canvas.addEventListener("mousedown", (e) => {
+  // Before start drawing, save the last version of the drawing into the canvasStorage variable
+  canvasStorage = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  isDrawing = true;   // Enable drawing
   [lastX, lastY] = [e.offsetX, e.offsetY];
 });
-canvas.addEventListener('mousemove', draw);
-canvas.addEventListener('mouseup', () => isDrawing = false);// when mouse-up >> means no longer drawing on the canvas
-canvas.addEventListener('mouseout', () => isDrawing = false);// when mouse-up >> means no longer drawing on the canvas
 
-const undo = document.getElementById('undo');
+// Call the draw function when move the mouse >> so if drawing is enabled, will execute it
+canvas.addEventListener("mousemove", draw);
 
-undo.addEventListener('click', () => {
-  ctx.clearRect(0, 0, 620, 620);    // Clear the canvas
-  ctx.putImageData(temp, 0, 0);     // Fill the canvas with the content of the 'temp' variable
-      // Fill the canvas with the content of the top x of the 'backup' array
-      // Remove the top x of the 'backup' array
+// Stop drawing (ie set isDrawing to False) when release the mouse or move the mouse outside of the canvas
+canvas.addEventListener("mouseup", () => isDrawing = false);
+canvas.addEventListener("mouseout", () => isDrawing = false);
+
+//////// ENABLE UNDO AND SAVE BUTTONS ////////
+
+// Enable undo button
+// CURRENTLY ONLY ABLE TO UNDO THE 1 LAST STEP >> FIX THIS
+undo.addEventListener("click", () => {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.putImageData(canvasStorage, 0, 0);
 });
+
+// Enable save button
+// SET THIS UP
+save.addEventListener("click", () => {
+  console.log("Save this to a file");
+});
+
+
+
+// To create rainbow effect in the brush colour:
+// let hue;
+// hue++;
+// if(hue >= 360) {
+//   hue = 0;
+// }

--- a/style.css
+++ b/style.css
@@ -89,11 +89,20 @@ ul li {
 /*////////////////////////////////////////////////*/
 /*////////////////////////////////////////////////*/
 /*////////////////////////////////////////////////*/
-/* Styling the canvas */
-/* Need to define the canvas size & position within script.js to enable drawing within the desired area */
+/* Styling the canvases */
+/* The canvases' size & position within script.js to enable drawing within the desired area */
 
 canvas {
   position: fixed;
 }
-/* Done styling the canvas */
+
+/* Set the drawing canvas to be on top of the background canvas */
+#drawingArea {
+  z-index: 99;
+}
+
+#drawingBackground {
+  z-index: 1;
+}
+/* Done styling the canvases */
 /*////////////////////////////////////////////////*/


### PR DESCRIPTION
- Added feature to change the background colour without overwriting the drawing; Enabled this by:
  - Adding a second canvas for the background colour behind the primary canvas, and
  - Removing the background colour from the primary canvas
- Cleaning up the code:
  - Removing commented out code
  - Restructuring the code so it looks cleaner and more easy to get an overview of the code
  - Updating variable names and function content, to remove everything that is not necessary for the site functions to work